### PR TITLE
Improve Homebrew aliases correctness

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,20 +1,20 @@
 brew-clean() {
     setopt localoptions rmstarsilent
     brew autoremove && \
-    brew bundle cleanup --verbose --force --global &&\
+    brew bundle cleanup --force --global && \
     brew cleanup --verbose --prune=all --scrub && \
-    du -sh "$(brew --cache)/*" && \
-    rm -vrf "$(brew --cache)/*"
+    du -sh "$(brew --cache)"/* && \
+    rm -vrf "$(brew --cache)"/*
 }
 
 brew-add() {
-    brew install $@ && \
-    brew bundle --verbose --global add $@
+    brew install "$@" && \
+    brew bundle --verbose --global add "$@"
 }
 
 brew-remove() {
-    brew uninstall $@ && \
-    brew bundle --verbose --global remove $@
+    brew uninstall "$@" && \
+    brew bundle --verbose --global remove "$@"
 }
 
 brew-install() {


### PR DESCRIPTION
## Summary

Fix invalid Homebrew Bundle cleanup flags and improve shell argument handling in `.aliases`.

## Changes

### `brew-clean`
- Remove unsupported `--verbose` flag from `brew bundle cleanup`
- Fix quoted cache globs so `*` expands correctly

### `brew-add` / `brew-remove`
- Quote `"$@"` to preserve argument boundaries and support package names with spaces safely

## Rationale

Recent Homebrew versions reject:

```sh
brew bundle cleanup --verbose
```

with:

```text
Error: Invalid usage: The `cleanup` subcommand does not accept the `-v` switch.
```

The cache cleanup commands were also quoting the glob itself:

```sh
"$(brew --cache)/*"
```

which prevents shell expansion.

This PR keeps behavior unchanged otherwise and limits the scope to shell correctness and Homebrew compatibility.